### PR TITLE
update to julia 1.x

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.5'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 1.4
+  - nightly
 notifications:
   email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("Psychro"))`); Pkg.pin("Psychro"); Pkg.resolve()'
-  - julia -e 'using Psychro; @assert isdefined(:Psychro); @assert typeof(Psychro) === Module'
+jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,26 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ConstructionBase]]
+git-tree-sha1 = "a2a6a5fea4d6f730ec4c18a76d27ec10e8ec1c50"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.0.0"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Unitful]]
+deps = ["ConstructionBase", "LinearAlgebra", "Random"]
+git-tree-sha1 = "ad27b1a82c81d2bb65fa3a94fa05b98136eefaad"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.4.1"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Unitful = "0.15 - 1.4.1"
+Unitful = "^1.4.1"
 julia = "1.4.1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Psychro"
+uuid = "004b34f0-5971-4be0-928f-8519ce193c55"
+authors = ["Paulo Jabardo", "IPT"]
+version = "0.1.0"
+
+[deps]
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+Unitful = "0.15 - 1.4.1"
+julia = "1.4.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ This package provides Julia with functions to compute some thermodynamic propert
 
 Besides moist air, this package also calculates the properties of dry air and saturated water vapor. It is part of a larger effort to model the thermodynamic (and transport) properties of different types of fluids.
 
+## instalation
 
+julia-repl```
+julia> ]
+(v1.4) pkg> add https://github.com/pjabardo/Psychro.jl/
+```
 
 ## User interface - Thermodynamic properties of moist air, dry air and saturated water vapor.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.6
-Unitful

--- a/src/hyland83.jl
+++ b/src/hyland83.jl
@@ -187,8 +187,6 @@ This implements equation 18 from [1].
  * Output: Pa
 """
 function Pws_s(Tk)
-
-  
     exp( (mm[1] + Tk*(mm[2] + Tk*(mm[3] + Tk*(mm[4] + Tk*(mm[5] + Tk*mm[6])))))/Tk + mm[7] * log(Tk) )
 end
 
@@ -383,7 +381,7 @@ Molar entropy of saturated vapor. Eq. 20 reference [1].
 """
 function molarentropyvapor(Tk)
     p = Pws(Tk)
-    s1 = @polyeval(Tk, ww, 6) + ww[7]*log(Tk)
+    s1 = polyeval(Tk, ww, 6) + ww[7]*log(Tk)
     s2 = -R*log(p) - R*p * ( (Blin(Tk) + Tk*dBlin(Tk)) + p/2 * (Clin(Tk) + Tk*dClin(Tk)) )
 
     return s1*Mv + s2

--- a/src/hyland83a.jl
+++ b/src/hyland83a.jl
@@ -112,21 +112,20 @@ dCaaa(Tk) = 1.0/(Tk*Tk) * (0.190905e-6 - 1.264934e-4/Tk)
 
 
 """
-    ```Zair(Tk, P, EPS, MAXITER)```
+    ```Zair(Tk, P)```
 
 Compressibility factor of dry air.
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
+
  * Output: Z (nondimensional)
 """
-function Zair(Tk, P, EPS=1e-8, MAXITER=100)
+function Zair(Tk, P)
     vm0 = R*Tk/P
     b0 = Baa(Tk) / vm0
     c0 = Caaa(Tk) / (vm0*vm0)
-    z = calcz(b0, c0, EPS, MAXITER)
+    z = calcz(b0, c0)
 end
 
 """
@@ -137,17 +136,15 @@ This function requires iteration to compute the volume.
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: molar volume in m^3/mol
 """
-function molarvolumeair(Tk, P, EPS=1e-8, MAXITER=100)
+function molarvolumeair(Tk, P)
 
     vm0 = R*Tk/P
 
     b0 = Baa(Tk)/vm0
     c0 = Caaa(Tk)/(vm0*vm0)
-    z = calcz(b0, c0, EPS, MAXITER)
+    z = calcz(b0, c0)
     
     return z*vm0
 end
@@ -159,11 +156,9 @@ Specific volume of dry air. Uses `molarvolumeair`.
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: molar volume in m^3/kg
 """
-volumeair(Tk, P, EPS=1e-8, MAXITER=100) = molarvolumeair(Tk, P, EPS, MAXITER) / Ma
+volumeair(Tk, P) = molarvolumeair(Tk, P) / Ma
 
 
 """
@@ -173,16 +168,14 @@ Molar enthalpy of dry air. Equation 13 of reference [2]
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: m^3/mol
 """
-function molarenthalpyair(Tk, P, EPS=1e-8, MAXITER=100)
+function molarenthalpyair(Tk, P)
     h1 = -0.79078691e4 + Tk*(0.28709015e2 +
                              Tk*(0.26431805e-2 +
                                  Tk*(-0.10405863e-4 +
                                      Tk*(0.18660410e-7 - 0.97843331e-11*Tk))))
-    va = molarvolumeair(Tk, P, EPS, MAXITER)
+    va = molarvolumeair(Tk, P)
 
     h2 = R*Tk/va * ( (Baa(Tk) - Tk*dBaa(Tk)) + (Caaa(Tk) - 0.5*Tk*dCaaa(Tk))/va )
 
@@ -198,12 +191,11 @@ Specific enthalpy of dry air. Equation 13 of reference [2]
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
+
  * Output: m^3/kg
 """
-function enthalpyair(Tk, P, EPS=1e-8, MAXITER=100)
-    return molarenthalpyair(Tk, P, EPS, MAXITER) / Ma
+function enthalpyair(Tk, P)
+    return molarenthalpyair(Tk, P) / Ma
     
 end
 
@@ -220,14 +212,12 @@ Specific entropy of dry air. Equation 14 of reference [2]
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: m^3/(kg.K)
 """
-function molarentropyair(Tk, P, EPS=1e-8, MAXITER=100)
+function molarentropyair(Tk, P)
 
-    s1 = @polyeval(Tk, ℓ, 5) + ℓ[6]*log(Tk) - R*log(P/101325.0)
-    va = molarvolumeair(Tk, P, EPS, MAXITER)
+    s1 = polyeval(Tk, ℓ, 5) + ℓ[6]*log(Tk) - R*log(P/101325.0)
+    va = molarvolumeair(Tk, P)
     s2 = R*log(P*va/R/Tk) - R/va * ( (Baa(Tk) + Tk*dBaa(Tk)) + 0.5/va * (Caaa(Tk) + Tk*dCaaa(Tk)))
 
     return (s1 + s2) 
@@ -243,13 +233,11 @@ Specific entropy of dry air. Equation 14 of reference [2]
 
  * `Tk` Temperature in K
  * `P` Pressure in Pa
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: m^3/(kg.K)
 """
-function entropyair(Tk, P, EPS=1e-8, MAXITER=100)
+function entropyair(Tk, P)
 
-    return molarentropyair(Tk, P, EPS, MAXITER) / Ma
+    return molarentropyair(Tk, P) / Ma
 end
 
 
@@ -482,7 +470,7 @@ Molar fraction of water vapor in saturated moist air
  * Output: molar fraction
 
 """
-molarfracmoist_sat(Tk, P) = efactor(Tk, P) * Pws(Tk) / P
+molarfracmoist_sat(Tk, P,EPS=1e-8, MAXITER=200) = efactor(Tk, P,EPS, MAXITER) * Pws(Tk) / P
 
 
 
@@ -666,7 +654,7 @@ Assumes a real gas.
  * `xv`  Molar fraction of water vapor
  * Output: molar volume in m^3/mol
 """
-molarvolumemoist(Tk, P, xv, EPS=1e-8, MAXITER=100) = Zmoist(Tk, P, xv, EPS, MAXITER) * R * Tk / P
+molarvolumemoist(Tk, P, xv) = Zmoist(Tk, P, xv) * R * Tk / P
 
 """
     ```volumemoist```
@@ -680,7 +668,7 @@ by a mixture of dry air and water vapor per kg of dry air.
  * `xv`  Molar fraction of water vapor
  * Output: molar volume in m^3/kg of dry air.
 """
-volumemoist(Tk, P, xv, EPS=1e-8, MAXITER=100) = molarvolumemoist(Tk,P,xv,EPS,MAXITER) / (Ma*(1-xv))
+volumemoist(Tk, P, xv) = molarvolumemoist(Tk,P,xv) / (Ma*(1-xv))
 
 
 """
@@ -691,17 +679,15 @@ Compressibility factor of moist air.
  * `Tk` Temperature in K
  * `P` Pressure in Pa
  * `xv` molar fraction of water vapor.
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: Z (nondimensional)
 """
-function Zmoist(Tk, P, xv, EPS=1e-8, MAXITER=500)
+function Zmoist(Tk, P, xv)
 
     vm0 = R*Tk/P
     b0 = Bm(Tk, xv)/vm0
     c0 = Cm(Tk, xv)/(vm0*vm0)
     
-    return calcz(b0, c0, EPS, MAXITER, 1.0)
+    return calcz(b0, c0)
 end
 
 
@@ -722,16 +708,14 @@ Molar enthalphy of moist air defined as enthalpy dry air.
  * `Tk` Temperature in K
  * `P` Pressure in Pa
  * `xv` molar fraction of water vapor.
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: J/mol
 
 """
-function molarenthalpymoist(Tk, P, xv, EPS=1e-8, MAXITER=100)
+function molarenthalpymoist(Tk, P, xv)
     xa = 1.0-xv
-    h1 = xa*(@polyeval(Tk, a, 6) -7914.1982)
-    h2 = xv*(@polyeval(Tk, d, 6) + 35994.17)
-    vm = molarvolumemoist(Tk, P, xv, EPS, MAXITER)
+    h1 = xa*(polyeval(Tk, a, 6) -7914.1982)
+    h2 = xv*(polyeval(Tk, d, 6) + 35994.17)
+    vm = molarvolumemoist(Tk, P, xv)
     h3 = R*Tk/vm * (Bm(Tk, xv) - Tk*dBm(Tk,xv)
                     + 1/vm*( Cm(Tk,xv) - 0.5*Tk*dCm(Tk,xv) ) )
     return (h1 + h2 + h3)
@@ -747,13 +731,11 @@ dry air.
  * `Tk` Temperature in K
  * `P` Pressure in Pa
  * `xv` molar fraction of water vapor.
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: J/kg of dry air
 
 """
-function enthalpymoist(Tk, P, xv, EPS=1e-8, MAXITER=100)
-    hm = molarenthalpymoist(Tk, P, xv, EPS, MAXITER)
+function enthalpymoist(Tk, P, xv)
+    hm = molarenthalpymoist(Tk, P, xv)
     return hm / ((1-xv)*Ma)
 end
 
@@ -770,7 +752,7 @@ const k = (0.2196603e1, 0.19743819e-1, -0.70128225e-4,
 
 
 """
-    molarentropymoist(Tk, P, xv, EPS=1e-8, MAXITER=100)
+    molarentropymoist(Tk, P, xv)
 
 Molar entropy of moist air defined as entropy per kg of
 dry air.
@@ -778,17 +760,16 @@ dry air.
  * `Tk` Temperature in K
  * `P` Pressure in Pa
  * `xv` molar fraction of water vapor.
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
+
  * Output: J/mol/K of dry air
 
 """
-function molarentropymoist(Tk, P, xv, EPS=1e-8, MAXITER=100)
+function molarentropymoist(Tk, P, xv)
     xa = 1.0-xv
-    h1 =  @polyeval(Tk, g, 5) + g[6]*log(Tk) - 196.125465
-    h2 =  @polyeval(Tk, k, 6) + k[7]*log(Tk) - 63.31449
+    h1 =  polyeval(Tk, g, 5) + g[6]*log(Tk) - 196.125465
+    h2 =  polyeval(Tk, k, 6) + k[7]*log(Tk) - 63.31449
 
-    z = Zmoist(Tk, P, xv, EPS, MAXITER)
+    z = Zmoist(Tk, P, xv)
     vm = z*R*Tk/P
     
     h3 = -R * log(P / 101325.0) + xa*R*log(z/xa)
@@ -811,14 +792,12 @@ dry air.
  * `Tk` Temperature in K
  * `P` Pressure in Pa
  * `xv` molar fraction of water vapor.
- * `EPS`: Acceptable error
- * `MAXITER`: Maixmum number of iterations
  * Output: J/kg/K of dry air
 
 """
-function entropymoist(Tk, P, xv, EPS=1e-8, MAXITER=100)
+function entropymoist(Tk, P, xv)
 
-    return molarentropymoist(Tk, P, xv, EPS, MAXITER) / ( (1-xv)*Ma )
+    return molarentropymoist(Tk, P, xv) / ( (1-xv)*Ma )
     
 end
 

--- a/src/moistair.jl
+++ b/src/moistair.jl
@@ -491,6 +491,7 @@ end
 function compressfactor(::Type{MoistAir}, Tk, ::Type{T}, y, P) where {T<:PsychroProperty}
     @assert 173.1 < Tk < 473.2 "Out of range error: Temperature should be between 173.15 K and 473.15 K!"
     @assert 0 <= P < 5e6 "Out of range error: Pressure should be below 5×10⁶ Pa"
+  
 
     xv = molarfrac(Tk, T, y, P)
     Zmoist(Tk, P, xv)
@@ -631,7 +632,7 @@ function dewpoint(::Type{MoistAir}, Tk, ::Type{T}, y, P) where {T<:PsychroProper
     if T==DewPoint
         return y
     end
-    
+
     xv = molarfrac(Tk, T, y, P)
     D = calcdewpoint(Tk, P, xv)
     return D

--- a/src/moistair.jl
+++ b/src/moistair.jl
@@ -410,7 +410,7 @@ function molarfrac(Tk, ::Type{HumRat}, w, P)
 end
 
 function molarfrac(Tk, ::Type{SpecHum}, q, P)
-    q * Ma / (Mv + r*(Ma - Mv))
+    q * Ma / (Mv + q*(Ma - Mv))
 end
 
 function molarfrac(Tk, ::Type{RelHum}, rel, P)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -80,8 +80,8 @@ end
 function cardan(poly::NTuple{4,T}) where {T<:AbstractFloat}
     # Cubic equation solver for complex polynomial (degree=3)
     # http://en.wikipedia.org/wiki/Cubic_function   Lagrange's method
-    third = 1//3
-    a1  =  T(1.0)
+    third = 0.3333333333333333 #speeds up the calculation
+    a1  =  T(1.0) #in the original cardan, there is a divition here (1/a[4]). in this particular case its not necessary
     E1  = -complex(poly[3])*a1
     E2  =  complex(poly[2])*a1
     E3  = -complex(poly[1])*a1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using Psychro
 
 include("test_utilities.jl")

--- a/test/test_hyland83.jl
+++ b/test/test_hyland83.jl
@@ -1,36 +1,37 @@
 # =================================================================================================
 # =                                         Hyland83.jl                                           =
 # =================================================================================================
-
+@testset "Hyland83" begin
 # Appendix of ref. [1]. First table
-# Specific volume of saturated ice:
+@testset "Specific volume of saturated ice" begin
 @test 1.0768e-3 ≈ Psychro.volumeice(173.15) atol=0.0001e-3
 @test 1.0829e-3 ≈ Psychro.volumeice(223.15) atol=0.0001e-3
 @test 1.0909e-3 ≈ Psychro.volumeice(273.16) atol=0.0001e-3
-
-# Specific volume of saturated liquid water
+end
+@testset "Specific volume of saturated liquid water" begin
 @test 1.00021e-3 ≈ Psychro.volumewater(273.16) atol=0.00001e-3
 @test 1.01215e-3 ≈ Psychro.volumewater(323.15) atol=0.00001e-3
 @test 1.04346e-3 ≈ Psychro.volumewater(373.15) atol=0.00001e-3 # In the paper there is a typo in the power of 10: 1.04346e10
 @test 1.09050e-3 ≈ Psychro.volumewater(423.15) atol=0.00001e-3
 @test 1.15653e-3 ≈ Psychro.volumewater(473.15) atol=0.00001e-3
+end
 
-
-# Saturation enthalpy of saturated ice
+@testset "Saturation enthalpy of saturated ice" begin
 @test -507.215e3 ≈ Psychro.enthalpyice(173.15) atol=0.001e3
 @test -429.413e3 ≈ Psychro.enthalpyice(223.15) atol=0.001e3
 @test -333.429e3 ≈ Psychro.enthalpyice(273.15) atol=0.001e3  # The table presents -333.409. Typo???
+end
 
-# Saturation enthalpy of saturated liquid water
+@testset "Saturation enthalpy of saturated liquid water" begin
 @test 0.0 ≈ Psychro.enthalpywater(273.16) atol=1.0
 @test 209.330e3 ≈ Psychro.enthalpywater(323.15) atol=5
 @test 419.158e3 ≈ Psychro.enthalpywater(373.15) atol=5
 @test 632.210e3 ≈ Psychro.enthalpywater(423.15) atol=9
 @test 852.329e3 ≈ Psychro.enthalpywater(473.15) atol=15
-
+end
 
 # Table 2 of reference [2]
-# Enhancement factor
+@testset "Enhancement factor" begin
 P = 0.1e6
 @test 1.0105 ≈ Psychro.efactor(173.15, P) atol=0.0001
 @test 1.0039 ≈ Psychro.efactor(273.15, P) atol=0.0001
@@ -61,21 +62,23 @@ P = 5.0e6
 @test 1.116 ≈ Psychro.efactor(443.15, P) atol=0.001
 @test 1.117 ≈ Psychro.efactor(453.15, P) atol=0.001
 @test 1.116 ≈ Psychro.efactor(473.15, P) atol=0.001
+end
 
-# Saturation pressure of water vapor over ice
+@testset "Saturation pressure of water vapor over ice" begin
 # Second table in the appendix of reference [1]
 @test 1.40510e-3 ≈ Psychro.Pws_s(173.15) atol=0.00001e-3
 @test 6.11153e2 ≈ Psychro.Pws_s(273.15) atol=0.00001e2
+end
 
-# Saturation pressure of water vapor over liquid water
+@testset "Saturation pressure of water vapor over liquid water" begin
 # Second table in the appendix of reference [1]
 @test 6.11213e2 ≈ Psychro.Pws_l(273.15) atol=0.00001e2
 @test 1.01419e5 ≈ Psychro.Pws_l(373.15) atol=0.00001e5
 @test 1.55507e6 ≈ Psychro.Pws_l(473.15) atol=0.00001e6
+end
 
 
-
-# Testing saturation temperature function:
+@testset " saturation temperature function" begin
 @test Psychro.Tws(Psychro.Pws_s(173.15)) ≈ 173.15 atol=1e-5
 @test Psychro.Tws(Psychro.Pws_s(223.15)) ≈ 223.15 atol=1e-5
 @test Psychro.Tws(Psychro.Pws_s(273.15)) ≈ 273.15 atol=1e-5
@@ -84,23 +87,25 @@ P = 5.0e6
 @test Psychro.Tws(Psychro.Pws_l(323.15)) ≈ 323.15 atol=1e-5
 @test Psychro.Tws(Psychro.Pws_l(373.15)) ≈ 373.15 atol=1e-5
 @test Psychro.Tws(Psychro.Pws_l(473.15)) ≈ 473.15 atol=1e-5
+end
 
-
-# First virial coefficient of saturated vapor B'
+@testset "First virial coefficient of saturated vapor B'" begin
 # Second table in the appendix of reference [1]
 @test -3.2939e-5 ≈ Psychro.Blin(173.15) atol=0.0001e-5
 @test -8.3497e-7 ≈ Psychro.Blin(273.15) atol=0.0001e-7
 @test -1.4658e-7 ≈ Psychro.Blin(373.15) atol=0.0001e-5
 @test -5.0508e-8 ≈ Psychro.Blin(473.15) atol=0.0001e-5
+end
 
-# Second virial coefficient of saturated vapor C'
+@testset "Second virial coefficient of saturated vapor C'" begin
 # Second table in the appendix of reference [1]
 @test -4.6563e-9 ≈ Psychro.Clin(173.15) atol=0.0001e-9
 @test -2.0928e-12 ≈ Psychro.Clin(273.15) atol=0.0001e-12
 @test -5.7548e-14 ≈ Psychro.Clin(373.15) atol=0.0001e-14
 @test -6.3933e-15 ≈ Psychro.Clin(473.15) atol=0.0001e-15
+end
 
-# Specific enthalpy of saturated water vapor
+@testset "Specific enthalpy of saturated water vapor" begin
 # First table of the appendix of ref. [1]
 @test 2315.87 ≈ Psychro.enthalpyvapor(173.15)/1000 atol=0.01
 @test 2408.41 ≈ Psychro.enthalpyvapor(223.15)/1000 atol=0.01
@@ -109,8 +114,9 @@ P = 5.0e6
 @test 2675.46 ≈ Psychro.enthalpyvapor(373.15)/1000 atol=0.01
 @test 2746.15 ≈ Psychro.enthalpyvapor(423.15)/1000 atol=0.01
 @test 2793.11 ≈ Psychro.enthalpyvapor(473.15)/1000 atol=0.01
+end
 
-# Specific volume of saturated water vapor
+@testset "Specific volume of saturated water vapor" begin
 # First table of the appendix of ref. [1]
 @test 5.6873e7 ≈ Psychro.volumevapor(173.15) atol=0.0001e7
 @test 2.6146e4 ≈ Psychro.volumevapor(223.15) atol=0.0001e4
@@ -119,9 +125,9 @@ P = 5.0e6
 @test 1.6718e0 ≈ Psychro.volumevapor(373.15) atol=0.0001e0
 @test 3.9253e-1 ≈ Psychro.volumevapor(423.15) atol=0.0001e-1
 @test 1.2722e-1 ≈ Psychro.volumevapor(473.15) atol=0.0001e0
+end
 
-
-# Specific entropy of saturated water vapor
+@testset "Specific entropy of saturated water vapor" begin
 # First table of the appendix of ref. [1]
 @test 14.30387 ≈ Psychro.entropyvapor(173.15)/1000 atol=0.00005
 @test 11.10965 ≈ Psychro.entropyvapor(223.15)/1000 atol=0.00005
@@ -130,4 +136,5 @@ P = 5.0e6
 @test  7.35365 ≈ Psychro.entropyvapor(373.15)/1000 atol=0.00005
 @test  6.83731 ≈ Psychro.entropyvapor(423.15)/1000 atol=0.00005
 @test  6.43218 ≈ Psychro.entropyvapor(473.15)/1000 atol=0.00005
-
+end
+end

--- a/test/test_hyland83a.jl
+++ b/test/test_hyland83a.jl
@@ -5,69 +5,83 @@
 #=
 Testing the virial coefficients. Table 1 from reference [2].
 =#
-# Baa
+@testset "Hyland83a" begin
+@testset "Virial Coeffients" begin
+
+@testset "Baa" begin
 @test -55.94 ≈ Psychro.Baa(173.15)*1e6 atol=0.01
 @test -13.15 ≈ Psychro.Baa(273.15)*1e6 atol=0.01
 @test 3.72 ≈ Psychro.Baa(373.15)*1e6 atol=0.01
 @test 12.31 ≈ Psychro.Baa(473.15)*1e6 atol=0.01
+end
 
-# dBaa/dT
+
+@testset "dBaa/dT" begin
 @test 0.7240 ≈ Psychro.dBaa(173.15)*1e6 atol=0.0001
 @test 0.2460 ≈ Psychro.dBaa(273.15)*1e6 atol=0.0001
 @test 0.1146 ≈ Psychro.dBaa(373.15)*1e6 atol=0.0001
 @test 0.0640 ≈ Psychro.dBaa(473.15)*1e6 atol=0.0001
+end
 
-# Caaa
+@testset "Caaa" begin
 @test 2267.0 ≈ Psychro.Caaa(173.15)*1e12 atol=1.0
 @test 1409.0 ≈ Psychro.Caaa(273.15)*1e12 atol=1.0
 @test 1202.0 ≈ Psychro.Caaa(373.15)*1e12 atol=1.0
 @test 1139.0 ≈ Psychro.Caaa(473.15)*1e12 atol=1.0
+end
 
-# dCaaa/dT
+@testset "dCaaa/dT" begin
 @test -18.00 ≈ Psychro.dCaaa(173.15)*1e12 atol=0.01
 @test -3.65 ≈ Psychro.dCaaa(273.15)*1e12 atol=0.01
 @test -1.06 ≈ Psychro.dCaaa(373.15)*1e12 atol=0.01
 @test -0.34 ≈ Psychro.dCaaa(473.15)*1e12 atol=0.01
+end
 
-# Baw
+@testset "Baw" begin
 @test -93.3 ≈ Psychro.Baw(173.15)*1e6 atol=0.1
 @test -36.4 ≈ Psychro.Baw(273.15)*1e6 atol=0.1
 @test -14.5 ≈ Psychro.Baw(373.15)*1e6 atol=0.1
 @test -3.1 ≈ Psychro.Baw(473.15)*1e6 atol=0.1
+end
 
-# dBaw/dT
+@testset "dBaw/dT" begin
 @test 1.01 ≈ Psychro.dBaw(173.15)*1e6 atol=0.01
 @test 0.318 ≈ Psychro.dBaw(273.15)*1e6 atol=0.001
 @test 0.151 ≈ Psychro.dBaw(373.15)*1e6 atol=0.001
 @test 0.0869 ≈ Psychro.dBaw(473.15)*1e6 atol=0.0001
+end
 
-# Caaw
+@testset "Caaw" begin
 @test 1023 ≈ Psychro.Caaw(173.15)*1e12 atol=1.0
 @test 861 ≈ Psychro.Caaw(273.15)*1e12 atol=1.0
 @test 696 ≈ Psychro.Caaw(373.15)*1e12 atol=1.0
 @test 627 ≈ Psychro.Caaw(473.15)*1e12 atol=1.0
+end
 
-# dCaaw/dT
+@testset "dCaaw/dT" begin
 @test  5.56 ≈ Psychro.dCaaw(173.15)*1e12 atol=0.01
 @test -2.44 ≈ Psychro.dCaaw(273.15)*1e12 atol=0.01
 @test -1.02 ≈ Psychro.dCaaw(373.15)*1e12 atol=0.01
 @test -0.457 ≈ Psychro.dCaaw(473.15)*1e12 atol=0.001
+end
 
-# Caww
+@testset "Caww" begin
 @test -2.0e7 ≈ Psychro.Caww(173.15)*1e12 atol=0.1e7
 @test -2.2e5 ≈ Psychro.Caww(273.15)*1e12 atol=0.1e5
 @test -3.0e4 ≈ Psychro.Caww(373.15)*1e12 atol=0.1e4
 @test -8.4e3 ≈ Psychro.Caww(473.15)*1e12 atol=0.1e3
+end
 
-# dCaww/dT
+@testset "dCaww/dT" begin
 @test 1.61e6 ≈ Psychro.dCaww(173.15)*1e12 atol=0.01e6
 @test 6.05e3 ≈ Psychro.dCaww(273.15)*1e12 atol=0.01e3
 @test    456 ≈ Psychro.dCaww(373.15)*1e12 atol=1.0
 @test   86.9 ≈ Psychro.dCaww(473.15)*1e12 atol=0.1
 # Note that on table 1, the last line is 8.69 instead of 86.9. Probably a typo in the paper.
+end
+end
 
-
-# Specific volume of dry air
+@testset "Specific volume of dry air" begin
 # Table 3
 P = 0.1e6
 @test 0.49510 ≈ Psychro.volumeair(173.15, P) atol=0.00003
@@ -92,8 +106,9 @@ P = 5e6
 @test 0.01533 ≈ Psychro.volumeair(273.15, P) atol=0.00003
 @test 0.02162 ≈ Psychro.volumeair(373.15, P) atol=0.00003
 @test 0.02763 ≈ Psychro.volumeair(473.15, P) atol=0.00003
+end
 
-# Specific enthalpy of dry air
+@testset "Specific enthalpy of dry air" begin
 # Table 3
 P = 0.1e6
 @test -100.63 ≈ Psychro.enthalpyair(173.15, P)/1000 atol=0.01
@@ -118,17 +133,19 @@ P = 5e6
 @test  -13.15 ≈ Psychro.enthalpyair(273.15, P)/1000 atol=0.01
 @test   94.63 ≈ Psychro.enthalpyair(373.15, P)/1000 atol=0.01
 @test  199.8 ≈ Psychro.enthalpyair(473.15, P)/1000 atol=0.1
+end
 
-# Specific entropy of dry air
+
+@testset "Specific entropy of dry air" begin
 P = 0.1e6
 @test -0.4550 ≈ Psychro.entropyair(173.15, P)/1000 atol=0.0001
 @test  0.0038 ≈ Psychro.entropyair(273.15, P)/1000 atol=0.0001
 @test  0.3182 ≈ Psychro.entropyair(373.15, P)/1000 atol=0.0001
 @test  0.5597 ≈ Psychro.entropyair(473.15, P)/1000 atol=0.0001
-
+end
 
 # Table 4, appendix of reference [2]
-# Testing the volume of saturated moist air
+@testset "Volume of saturated moist air" begin
 volmoist(Tk, P) = Psychro.volumemoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)
 P = 0.1e6
 @test 0.49510 ≈ volmoist(173.15, P) atol=0.00005
@@ -158,7 +175,9 @@ P=5e6
 @test 0.03077  ≈ volmoist(443.15, P) atol=0.00001
 @test 0.03315  ≈ volmoist(453.15, P) atol=0.00001
 @test 0.0402  ≈ volmoist(473.15, P) atol=0.0001
+end
 
+@testset "enthalpy of saturated moist air" begin
 hmoist(Tk, P) = Psychro.enthalpymoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)/1000
 P = 0.1e6
 @test -100.627 ≈ hmoist(173.15, P) atol=0.005
@@ -191,8 +210,9 @@ P = 5e6
 @test   534.1 ≈ hmoist(443.15, P) atol=0.5
 @test   672.0 ≈ hmoist(453.15, P) atol=1.0
 @test   1113.0 ≈ hmoist(473.15, P) atol=1.0
+end
 
-# Entropy of saturated moist air
+@testset "Entropy of saturated moist air" begin
 # Table 4 in the appendix of reference [2].
 smoist(Tk, P) = Psychro.entropymoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)/1000
 P = 0.1e6
@@ -226,3 +246,5 @@ P = 5e6
 @test   0.2901  ≈ smoist(443.15, P) atol=0.0002
 @test   0.6185  ≈ smoist(453.15, P) atol=0.0002
 @test   1.642  ≈ smoist(473.15, P) atol=0.002
+end
+end

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -2,7 +2,7 @@
 using Unitful
 
 # Testing th units part.
-
+@testset "Units" begin
 Tf = 70.0u"°F"
 Tc = uconvert(u"°C", Tf)
 Tk = uconvert(u"K", Tf)
@@ -32,11 +32,11 @@ v1 = enthalpym(DryAir, Tf, Pa, u"lb*inch^2/hr^2/kmol")
 v2 = enthalpym(DryAir, Tk.val, Pp.val)
 @test uconvert(u"J/mol", v1).val ≈ v2 rtol=1e-8
 
-v1 = entropy(DryAir, Tf, Pa, u"inch^2/hr^2/°F")
+v1 = entropy(DryAir, Tf, Pa, u"inch^2/hr^2/Ra")
 v2 = entropy(DryAir, Tk.val, Pp.val)
 @test uconvert(u"J/kg/K", v1).val ≈ v2 rtol=1e-8
 
-v1 = entropym(DryAir, Tf, Pa, u"lb*inch^2/hr^2/°F/kmol")
+v1 = entropym(DryAir, Tf, Pa, u"lb*inch^2/hr^2/Ra/kmol")
 v2 = entropym(DryAir, Tk.val, Pp.val)
 @test uconvert(u"J/mol/K", v1).val ≈ v2 rtol=1e-8
 
@@ -67,12 +67,13 @@ v1 = enthalpym(Vapor, Tf, u"lb*inch^2/hr^2/kmol")
 v2 = enthalpym(Vapor, Tk.val)
 @test uconvert(u"J/mol", v1).val ≈ v2 rtol=1e-8
 
-v1 = entropy(Vapor, Tf, u"inch^2/hr^2/°F")
+v1 = entropy(Vapor, Tf, u"inch^2/hr^2/Ra")
 v2 = entropy(Vapor, Tk.val)
 @test uconvert(u"J/kg/K", v1).val ≈ v2 rtol=1e-8
 
-v1 = entropym(Vapor, Tf, u"lb*inch^2/hr^2/°F/kmol")
-v2 = entropym(Vapor, Tk.val)
+v1 = entropym(Vapor, Tf, u"lb*inch^2/hr^2/Ra/kmol")
+v2 = entropym(Vapor
+, Tk.val)
 @test uconvert(u"J/mol/K", v1).val ≈ v2 rtol=1e-8
 
 v1 = compressfactor(Vapor, Tf)
@@ -89,7 +90,7 @@ w = Psychro.humrat(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
 q = Psychro.spechum(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
 x = Psychro.molarfrac(Tk.val, DewPoint, Dk.val, Pp.val)
 
-Bf = uconvert(u"°F", B*u"K")
+Bf = uconvert(u"Ra", B*u"K")
 
 x1 = Psychro.molarfrac(Tf, DewPoint, Df, Pl)
 x2 = Psychro.molarfrac(Tf, WetBulb, Bf, Pl)
@@ -167,11 +168,11 @@ x5 = enthalpym(MoistAir, Tf, RelHum, r, Pl, u"inch^2*lb/hr^2/kmol")
 
 
 x  = entropy(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
-x1 = entropy(MoistAir, Tf, DewPoint, Df, Pl, u"inch^2/hr^2/°F")
-x2 = entropy(MoistAir, Tf, WetBulb, Bf, Pl, u"inch^2/hr^2/°F")
-x3 = entropy(MoistAir, Tf, HumRat, w, Pl, u"inch^2/hr^2/°F")
-x4 = entropy(MoistAir, Tf, SpecHum, q, Pl, u"inch^2/hr^2/°F")
-x5 = entropy(MoistAir, Tf, RelHum, r, Pl, u"inch^2/hr^2/°F")
+x1 = entropy(MoistAir, Tf, DewPoint, Df, Pl, u"inch^2/hr^2/Ra")
+x2 = entropy(MoistAir, Tf, WetBulb, Bf, Pl, u"inch^2/hr^2/Ra")
+x3 = entropy(MoistAir, Tf, HumRat, w, Pl, u"inch^2/hr^2/Ra")
+x4 = entropy(MoistAir, Tf, SpecHum, q, Pl, u"inch^2/hr^2/Ra")
+x5 = entropy(MoistAir, Tf, RelHum, r, Pl, u"inch^2/hr^2/Ra")
 @test uconvert(u"J/kg/K", x1).val ≈ x rtol=1e-8
 @test uconvert(u"J/kg/K", x2).val ≈ x rtol=1e-8
 @test uconvert(u"J/kg/K", x3).val ≈ x rtol=1e-8
@@ -180,11 +181,11 @@ x5 = entropy(MoistAir, Tf, RelHum, r, Pl, u"inch^2/hr^2/°F")
 
 
 x  = entropym(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
-x1 = entropym(MoistAir, Tf, DewPoint, Df, Pl, u"inch^2/hr^2/°F*lb/kmol")
-x2 = entropym(MoistAir, Tf, WetBulb, Bf, Pl, u"inch^2/hr^2/°F*lb/kmol")
-x3 = entropym(MoistAir, Tf, HumRat, w, Pl, u"inch^2/hr^2/°F*lb/kmol")
-x4 = entropym(MoistAir, Tf, SpecHum, q, Pl, u"inch^2/hr^2/°F*lb/kmol")
-x5 = entropym(MoistAir, Tf, RelHum, r, Pl, u"inch^2/hr^2/°F*lb/kmol")
+x1 = entropym(MoistAir, Tf, DewPoint, Df, Pl, u"inch^2/hr^2/Ra*lb/kmol")
+x2 = entropym(MoistAir, Tf, WetBulb, Bf, Pl, u"inch^2/hr^2/Ra*lb/kmol")
+x3 = entropym(MoistAir, Tf, HumRat, w, Pl, u"inch^2/hr^2/Ra*lb/kmol")
+x4 = entropym(MoistAir, Tf, SpecHum, q, Pl, u"inch^2/hr^2/Ra*lb/kmol")
+x5 = entropym(MoistAir, Tf, RelHum, r, Pl, u"inch^2/hr^2/Ra*lb/kmol")
 @test uconvert(u"J/mol/K", x1).val ≈ x rtol=1e-8
 @test uconvert(u"J/mol/K", x2).val ≈ x rtol=1e-8
 @test uconvert(u"J/mol/K", x3).val ≈ x rtol=1e-8
@@ -208,11 +209,11 @@ x5 = compressfactor(MoistAir, Tf, RelHum, r, Pl)
 
 
 x  = dewpoint(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
-x1 = dewpoint(MoistAir, Tf, DewPoint, Df, Pl, u"°F")
-x2 = dewpoint(MoistAir, Tf, WetBulb, Bf, Pl, u"°F")
-x3 = dewpoint(MoistAir, Tf, HumRat, w, Pl, u"°F")
-x4 = dewpoint(MoistAir, Tf, SpecHum, q, Pl, u"°F")
-x5 = dewpoint(MoistAir, Tf, RelHum, r, Pl, u"°F")
+x1 = dewpoint(MoistAir, Tf, DewPoint, Df, Pl, u"Ra")
+x2 = dewpoint(MoistAir, Tf, WetBulb, Bf, Pl, u"Ra")
+x3 = dewpoint(MoistAir, Tf, HumRat, w, Pl, u"Ra")
+x4 = dewpoint(MoistAir, Tf, SpecHum, q, Pl, u"Ra")
+x5 = dewpoint(MoistAir, Tf, RelHum, r, Pl, u"Ra")
 @test uconvert(u"K", x1).val ≈ x rtol=1e-8
 @test uconvert(u"K", x2).val ≈ x rtol=1e-8
 @test uconvert(u"K", x3).val ≈ x rtol=1e-8
@@ -221,11 +222,11 @@ x5 = dewpoint(MoistAir, Tf, RelHum, r, Pl, u"°F")
 
 
 x  = wetbulb(MoistAir, Tk.val, DewPoint, Dk.val, Pp.val)
-x1 = wetbulb(MoistAir, Tf, DewPoint, Df, Pl, u"°F")
-x2 = wetbulb(MoistAir, Tf, WetBulb, Bf, Pl, u"°F")
-x3 = wetbulb(MoistAir, Tf, HumRat, w, Pl, u"°F")
-x4 = wetbulb(MoistAir, Tf, SpecHum, q, Pl, u"°F")
-x5 = wetbulb(MoistAir, Tf, RelHum, r, Pl, u"°F")
+x1 = wetbulb(MoistAir, Tf, DewPoint, Df, Pl, u"Ra")
+x2 = wetbulb(MoistAir, Tf, WetBulb, Bf, Pl, u"Ra")
+x3 = wetbulb(MoistAir, Tf, HumRat, w, Pl, u"Ra")
+x4 = wetbulb(MoistAir, Tf, SpecHum, q, Pl, u"Ra")
+x5 = wetbulb(MoistAir, Tf, RelHum, r, Pl, u"Ra")
 @test uconvert(u"K", x1).val ≈ x rtol=1e-8
 @test uconvert(u"K", x2).val ≈ x rtol=1e-8
 @test uconvert(u"K", x3).val ≈ x rtol=1e-8
@@ -270,3 +271,4 @@ x5 = spechum(MoistAir, Tf, RelHum, r, Pl)
 @test x3 ≈ x rtol=1e-8
 @test x4 ≈ x rtol=1e-8
 @test x5 ≈ x rtol=1e-8
+end

--- a/test/test_user.jl
+++ b/test/test_user.jl
@@ -2,26 +2,31 @@
 # =                                 High level interface                                          =
 # =================================================================================================
 
-# Testing higher level interface
+@testset "higher level interface test" begin
 
 #using Psychro
 
 Tk = 183.3:10.0:463.3
 Pa = [0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 49.0]*1e5
-
-# Test volume - saturated moist air
 xvs(Tk, P) = Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P
+
+
+volmoist(Tk, P) = Psychro.volumemoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)
+
+@testset "volume - saturated moist air" begin
 for p1 in Pa, t1 in Tk
-    x = xvs(t1, p1)
+    global x = xvs(t1, p1)
     if x <= 1.0
         v1 = volmoist(t1, p1)
         v2 = Psychro.volume(Psychro.MoistAir, t1, Psychro.RelHum, 1.0, p1)
         @test v1 ≈ v2 rtol=1e-6
     end
 end
-    
-# Test volume - dry air
+end
 
+
+
+@testset "volume - dry air" begin
 for p1 in Pa, t1 in Tk
     v1 = Psychro.volumeair(t1, p1)
     v2 = Psychro.volume(Psychro.MoistAir, t1, Psychro.RelHum, 0.0, p1)
@@ -29,20 +34,23 @@ for p1 in Pa, t1 in Tk
     @test v1 ≈ v2 rtol=1e-6
     @test v2 ≈ v3 rtol=1e-6
 end
+end
 
+==
 
-# Test enthalpy - saturated moist air
+@testset "enthalpy - saturated moist air" begin
+hmoist(Tk, P) = Psychro.enthalpymoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)/1000
 for p1 in Pa, t1 in Tk
-    x = xvs(t1, p1)
+    global x = xvs(t1, p1)
     if x <= 1.0
         v1 = hmoist(t1, p1)
         v2 = Psychro.enthalpy(Psychro.MoistAir, t1, Psychro.RelHum, 1.0, p1)/1000
         @test v1 ≈ v2 rtol=1e-4
     end
 end
+end
 
-
-# Test enthalpy - dry air
+@testset "enthalpy - dry air" begin
 
 for p1 in Pa, t1 in Tk
     v1 = Psychro.enthalpyair(t1, p1)
@@ -52,20 +60,22 @@ for p1 in Pa, t1 in Tk
     @test v1 ≈ v2 rtol=1e-4
     @test v2 ≈ v3 rtol=1e-4
 end
+end
 
+@testset "entropy - saturated moist air" begin
+smoist(Tk, P) = Psychro.entropymoist(Tk, P, Psychro.efactor(Tk,P)*Psychro.Pws(Tk)/P)/1000
 
-# Test entropy - saturated moist air
 for p1 in Pa, t1 in Tk
-    x = xvs(t1, p1)
+    global x = xvs(t1, p1)
     if x <= 1.0
         v1 = smoist(t1, p1)
         v2 = Psychro.entropy(Psychro.MoistAir, t1, Psychro.RelHum, 1.0, p1)/1000
         @test v1 ≈ v2 rtol=1e-6
     end
 end
+end
 
-
-# Test entropy - dry air
+@testset "entropy - dry air" begin
 
 for p1 in Pa, t1 in Tk
     v1 = Psychro.entropyair(t1, p1)
@@ -75,15 +85,16 @@ for p1 in Pa, t1 in Tk
     @test v1 ≈ v2 rtol=1e-4
     @test v2 ≈ v3 rtol=1e-4
 end
+end
 
-
-# Calculates M* in table 13 of reference [5]
+@testset "Calculations of M* in table 13 of reference [5]" begin
 function mfun(Tbu, P=101325.0)
     hs = Psychro.enthalpy(Psychro.MoistAir, Tbu, Psychro.RelHum, 1.0, P)
     ws = Psychro.humrat(Psychro.MoistAir, Tbu,  Psychro.RelHum, 1.0, P)
     hw = Psychro.enthalpywi(Tbu)
     return (hs - ws*hw)/1000
 end
+
 
 @test 12.94 ≈ mfun(2.0+273.15) atol=0.015
 @test 20.50 ≈ mfun(6.0+273.15) atol=0.015
@@ -110,13 +121,13 @@ function wfun(t, tbu, P=101325.0)
 
     return (ms - ha) / (hg - hw)
 end
+end
 
 
+@testset "Testing Table 20 from reference [5]" begin
 
-# Testing Table 20 from reference [5].
-
-Tk = vcat(5*ones(4), 25*ones(4), 50*ones(4)) + 273.15
-Tbu = [5.0, 2.0, -1.0, -3.0, 25.0, 20.0, 15.0, 10.0, 25.0, 22.0, 20.0, 19.0] + 273.15
+Tk = vcat(5*ones(4), 25*ones(4), 50*ones(4)) .+ 273.15
+Tbu = [5.0, 2.0, -1.0, -3.0, 25.0, 20.0, 15.0, 10.0, 25.0, 22.0, 20.0, 19.0] .+ 273.15
 Td = [5.0, -2.16, -11.92, -37.23, 25.0, 17.60, 7.73, -10.42, 13.47, 4.16, -5.48, -14.12]
 w = [5.42, 3.16, 1.35, 0.11, 20.17, 12.66, 6.56, 1.55, 9.67, 5.11, 2.39, 1.11]*1e-3
 rel = [100.0, 58.6, 25.1, 2.0, 100, 63.5, 33.2, 7.9, 12.5, 6.7, 3.1, 1.5]
@@ -125,7 +136,7 @@ h = [18.64, 12.97, 8.42, 5.30, 76.50, 57.38, 41.85, 29.09, 75.40, 63.58, 56.51, 
 s = [0.0697, 0.0490, 0.0319, 0.0195, 0.2698, 0.2048, 0.1506, 0.1039, 0.2610, 0.2192, 0.1934, 0.1808]
 
 P = 101325.0
-Td1 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)-273.15
+Td1 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P).- 273.15
 w1 =  Psychro.humrat.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)
 rel1 =  Psychro.relhum.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P) * 100
 vol1 =  Psychro.volume.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)
@@ -139,14 +150,16 @@ s1 =  Psychro.entropy.(Psychro.MoistAir, Tk, Psychro.WetBulb, Tbu, P)/1000
 @test maximum(abs, h1-h) ≈ 0.0 atol=0.01
 @test maximum(abs, s1-s) ≈ 0.0 atol=0.0001
 
-Tbu1 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.DewPoint, Td1+273.15, P)
+Tbu1 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.DewPoint, Td1 .+ 273.15, P)
 @test maximum(abs, Tbu1-Tbu) ≈ 0.0 atol=1e-4
 Tbu2 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P)
 @test maximum(abs, Tbu2-Tbu) ≈ 0.0 atol=1e-4
 Tbu3 = Psychro.wetbulb.(Psychro.MoistAir, Tk, Psychro.HumRat, w1/100, P)
 @test maximum(abs, Tbu2-Tbu) ≈ 0.0 atol=1e-4
 
-Td2 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.HumRat, w1, P)-273.15
+Td2 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.HumRat, w1, P) .- 273.15
 @test maximum(abs, Td2-Td1) ≈ 0.0 atol=1e-4
-Td3 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P)-273.15
+Td3 = Psychro.dewpoint.(Psychro.MoistAir, Tk, Psychro.RelHum, rel1/100, P) .- 273.15
 @test maximum(abs, Td3-Td1) ≈ 0.0 atol=1e-4
+end
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,10 +1,11 @@
 
-
+@testset "utilities - polyeval" begin
 # Testing the polynomial evaluation macro:
 p = randn(6)
 x = 0.33
-@test @evalpoly(x, p[1], p[2]) ≈ Psychro.@polyeval(x, p, 2) atol=1e-13
-@test @evalpoly(x, p[1], p[2], p[3]) ≈ Psychro.@polyeval(x, p, 3) atol=1e-13
-@test @evalpoly(x, p[1], p[2], p[3], p[4]) ≈ Psychro.@polyeval(x, p, 4) atol=1e-13
-@test @evalpoly(x, p[1], p[2], p[3], p[4], p[5]) ≈ Psychro.@polyeval(x, p, 5) atol=1e-13
-@test @evalpoly(x, p[1], p[2], p[3], p[4], p[5], p[6]) ≈ Psychro.@polyeval(x, p, 6) atol=1e-13
+@test @evalpoly(x, p[1], p[2]) ≈ Psychro.polyeval(x, p, 2) atol=1e-13
+@test @evalpoly(x, p[1], p[2], p[3]) ≈ Psychro.polyeval(x, p, 3) atol=1e-13
+@test @evalpoly(x, p[1], p[2], p[3], p[4]) ≈ Psychro.polyeval(x, p, 4) atol=1e-13
+@test @evalpoly(x, p[1], p[2], p[3], p[4], p[5]) ≈ Psychro.polyeval(x, p, 5) atol=1e-13
+@test @evalpoly(x, p[1], p[2], p[3], p[4], p[5], p[6]) ≈ Psychro.polyeval(x, p, 6) atol=1e-13
+end


### PR DESCRIPTION
hi, i wanted to update the package to julia 1.x (tested on julia 1.4.1)
the changes are:

- Unitful doesnt accept division by °F anymore, to use temperature in denominators, Rankine (Ra) is now used
- `calcz `now uses cardan algorithm for exact calculation of the Z, without iterations. with this, a lot of functions that required iteration arguments` (relax,ITERS,TOL)` dont have those arguments anymore (functions that perform newton iterations still have those arguments)
- added Manifest.toml, project.toml (with your name), removed REQUIRE
- update travis.yml to use actual julia instances
- organize tests in testsets
- polyeval now is a function that calls evalpoly (performance problems with evalpoly were fixed on 1.4)
